### PR TITLE
cargo: bump version-sync dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,5 +40,5 @@ replace = "https://docs.rs/rcgc/{{version}}"
 log = "0.4.6"
 
 [dev-dependencies]
-version-sync = "0.5"
+version-sync = "0.8"
 env_logger = "0.6.0"


### PR DESCRIPTION
The new version 0.8.0 requires Rust 2018, which this project is already using.